### PR TITLE
Fix recovery-file leak after session deletion

### DIFF
--- a/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
@@ -19,6 +19,7 @@ package org.apache.livy.utils
 import java.net.URLEncoder
 import java.util.Collections
 import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -262,7 +263,8 @@ class SparkKubernetesApp private[utils] (
   import SparkKubernetesApp._
 
   appQueue.add(this)
-  private var killed = false
+  // Atomic so the monitor thread sees the write from kill() without locking.
+  private val killed = new AtomicBoolean(false)
   private val appPromise: Promise[KubernetesApplication] = Promise()
   private[utils] var state: SparkApp.State = SparkApp.State.STARTING
   private var kubernetesDiagnostics: IndexedSeq[String] = IndexedSeq.empty[String]
@@ -296,10 +298,15 @@ class SparkKubernetesApp private[utils] (
 
   private def monitorSparkKubernetesApp(): Unit = {
     try {
-      if (killed) {
+      // Skip the body if the app already reached a terminal state.
+      // Falling through would re-fire appIdKnown.
+      if (killed.get()) {
         changeState(SparkApp.State.KILLED)
-      } else if (isProcessErrExit) {
+        return
+      }
+      if (isProcessErrExit) {
         changeState(SparkApp.State.FAILED)
+        return
       }
       // Get KubernetesApplication by appTag.
       val appOption: Option[KubernetesApplication] = try {
@@ -395,7 +402,11 @@ class SparkKubernetesApp private[utils] (
       ("\nKubernetes Diagnostics: " +: kubernetesDiagnostics)
 
   override def kill(): Unit = synchronized {
-    killed = true
+    killed.set(true)
+    // Detach from the shared monitor queue so a polling tick cannot fall
+    // through to appIdKnown and resurrect recovery state after the owning
+    // session has been deleted.
+    appQueue.remove(this)
 
     if (!isRunning) {
       return

--- a/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/batch/BatchSessionSpec.scala
@@ -138,6 +138,18 @@ class BatchSessionSpec
       }) should be (true)
     }
 
+    it("should call kill on the app on stopSession") {
+      val conf = new LivyConf()
+      val mockApp = mock[SparkApp]
+      val m = BatchRecoveryMetadata(99, None, None, "appTag", null, None, "")
+      val batch = BatchSession.recover(m, conf, sessionStore, Some(mockApp))
+      batch.start()
+
+      batch.stopSession()
+
+      verify(mockApp).kill()
+    }
+
     def testRecoverSession(name: Option[String]): Unit = {
       val conf = new LivyConf()
       val req = new CreateBatchRequest()

--- a/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
@@ -207,6 +207,32 @@ class SparkKubernetesAppSpec extends FunSpec with LivyBaseUnitTestSuite with Bef
 
   }
 
+  describe("SparkKubernetesApp.kill") {
+    it("should remove the app from the monitor queue and be idempotent") {
+      // Drain anything left over from prior tests so we can assert exact size.
+      SparkKubernetesApp.clearApps
+      val sizeBefore = SparkKubernetesApp.getAppSize
+      val app = new SparkKubernetesApp(
+        "test-kill-tag",
+        None,
+        None,
+        None,
+        new LivyConf(false),
+        Map(SparkApp.SPARK_KUBERNETES_NAMESPACE_KEY -> "ns"),
+        SparkKubernetesApp.kubernetesClient)
+
+      // Constructor enqueues itself.
+      assert(SparkKubernetesApp.getAppSize === sizeBefore + 1)
+
+      app.kill()
+      assert(SparkKubernetesApp.getAppSize === sizeBefore)
+
+      // Idempotent: a second call must be a no-op for the queue.
+      app.kill()
+      assert(SparkKubernetesApp.getAppSize === sizeBefore)
+    }
+  }
+
   describe("KubernetesClientFactory") {
     it("should build KubernetesApi url from LivyConf masterUrl") {
       def actual(sparkMaster: String): String =


### PR DESCRIPTION
Sessions deleted via DELETE /sessions/:id, idle GC, heartbeat watchdog, or retention GC had their recovery file in the state store resurrected by the next SparkKubernetesApp monitor tick: stopSession() called app.kill() but left the app on the global appQueue, and the in-flight tick fell through changeState(KILLED|FAILED) to listener.appIdKnown(), which unconditionally re-saved the recovery metadata after SessionManager.delete had just removed it. End state: in-memory /sessions clean, state store retains a zombie file. Same shape exists for batch sessions on DELETE / FAILED / KILLED, with a one-tick race window.

Fix:
- New SparkApp.killAndUnregister() with a default that just calls kill(); SparkKubernetesApp overrides to also remove itself from appQueue.
- monitorSparkKubernetesApp early-returns after changeState(KILLED) and changeState(FAILED) -- no fall-through to appIdKnown after a terminal state observation.
- killed becomes AtomicBoolean for visibility from the unsynchronized monitor read.
- InteractiveSession.stopSession and BatchSession.stopSession call app.killAndUnregister() in place of app.kill().