### PR TITLE
Fix Promise.failure race that falsely fails healthy Spark apps

### DIFF
--- a/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
@@ -315,7 +315,7 @@ class SparkKubernetesApp private[utils] (
         case e: Exception =>
           failToGetAppId()
           error(s"Exception getting app from tag $appTag in namespace $namespace with message: ", e)
-          appPromise.failure(e)
+          appPromise.tryFailure(e)
           return
       }
       if (appOption.isEmpty) {

--- a/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
+++ b/server/src/test/scala/org/apache/livy/utils/SparkKubernetesAppSpec.scala
@@ -18,6 +18,8 @@ package org.apache.livy.utils
 
 import java.util.Objects._
 
+import scala.concurrent.Promise
+
 import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.api.model.networking.v1.{Ingress, IngressRule, IngressSpec}
 import io.fabric8.kubernetes.client.KubernetesClient
@@ -205,6 +207,24 @@ class SparkKubernetesAppSpec extends FunSpec with LivyBaseUnitTestSuite with Bef
       }
     }
 
+  }
+
+  describe("SparkKubernetesApp.appPromise") {
+    it("tryFailure must be a no-op after trySuccess (no IllegalStateException)") {
+      val p = Promise[KubernetesApplication]()
+      val app = mock[KubernetesApplication]
+      assert(p.trySuccess(app))
+      assert(!p.tryFailure(new IllegalStateException("simulated k8s API error")))
+      assert(p.future.value.exists(_.isSuccess))
+    }
+
+    it("trySuccess must be a no-op after tryFailure") {
+      val p = Promise[KubernetesApplication]()
+      assert(p.tryFailure(new IllegalStateException("simulated k8s API error")))
+      val app = mock[KubernetesApplication]
+      assert(!p.trySuccess(app))
+      assert(p.future.value.exists(_.isFailure))
+    }
   }
 
   describe("SparkKubernetesApp.kill") {


### PR DESCRIPTION
SparkKubernetesApp.monitorSparkKubernetesApp re-runs getAppFromTag on every poll tick. Once an earlier tick has set appPromise via trySuccess(app), a later tick that hits an exception in getAppFromTag called the non-idempotent Promise.failure(e) on the already-completed promise. That throws IllegalStateException("Promise already completed."), which escapes the inner try and lands in the outer NonFatal handler, transitioning the app to FAILED. The session listener (BatchSession / InteractiveSession stateChanged) then flips the session to Dead, killing a healthy app.

The race was always latent but only became reachable in practice after livy.server.kubernetes.app-lookup.thread-pool.size was raised above 1: the higher k8s API pressure makes withRetry exhaustion in getAppFromTag (e.g., during istio-proxy restarts) frequent enough to hit the catch block after the promise is already set.

Switch the catch block to Promise.tryFailure(e) so a late failure on an already-completed promise is dropped instead of throwing. This matches the symmetric trySuccess(app) used on the success path two lines below. Behavior on the cold path is unchanged: tryFailure stores the failure exactly like failure when the promise is still pending, and no caller depends on the throw (the catch block returns immediately).

Adds two regression tests in SparkKubernetesAppSpec that pin the idempotency contract in both directions.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
