### PR TITLE
fix: claim session state files atomically to prevent silent session ID conflicts

### DIFF
--- a/server/src/main/scala/org/apache/livy/LivyConf.scala
+++ b/server/src/main/scala/org/apache/livy/LivyConf.scala
@@ -234,6 +234,11 @@ object LivyConf {
   val RECOVERY_ZK_STATE_STORE_KEY_PREFIX =
     Entry("livy.server.recovery.zk-state-store.key-prefix", "livy")
 
+  // Max number of times session creation retries with a fresh id when the id's state
+  // file already exists (exclusive-create collision) before failing with 503.
+  val SESSION_ID_COLLISION_MAX_RETRIES =
+    Entry("livy.server.session.id-collision.max-retries", 10)
+
   // Livy will cache the max no of logs specified. 0 means don't cache the logs.
   val SPARK_LOGS_SIZE = Entry("livy.cache-log.size", 200)
 

--- a/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/SessionServlet.scala
@@ -20,13 +20,16 @@ package org.apache.livy.server
 import java.security.AccessControlException
 import javax.servlet.http.HttpServletRequest
 
-import org.scalatra._
+import scala.annotation.tailrec
 import scala.concurrent._
 import scala.concurrent.duration._
+
+import org.scalatra._
 
 import org.apache.livy.{LivyConf, Logging}
 import org.apache.livy.rsc.RSCClientFactory
 import org.apache.livy.server.batch.BatchSession
+import org.apache.livy.server.recovery.StateFileCollisionException
 import org.apache.livy.sessions.{Session, SessionManager}
 import org.apache.livy.sessions.Session.RecoveryMetadata
 
@@ -54,6 +57,33 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
    * parsing the body of the request.
    */
   protected def createSession(req: HttpServletRequest): S
+
+  /**
+   * Wraps session creation with automatic retry when a session id cannot be
+   * claimed exclusively in the state store (its state file already exists). On
+   * each collision the in-memory counter has already been advanced by nextId(),
+   * so the next attempt uses a fresh id.
+   */
+  protected def withCollisionRetry(create: => S): S = {
+    val maxRetries = livyConf.getInt(LivyConf.SESSION_ID_COLLISION_MAX_RETRIES)
+    @tailrec
+    def attempt(n: Int): S = {
+      try {
+        create
+      } catch {
+        case e: StateFileCollisionException =>
+          if (n >= maxRetries) {
+            SessionServlet.error(s"Exhausted $maxRetries " +
+              s"retries for collision: ${e.getMessage}")
+            throw e
+          }
+          SessionServlet.warn(s"${e.getMessage} " +
+            s"(attempt ${n + 1}/$maxRetries), trying next ID")
+          attempt(n + 1)
+      }
+    }
+    attempt(0)
+  }
 
   /**
    * Returns a object representing the session data to be sent back to the client.
@@ -140,6 +170,12 @@ abstract class SessionServlet[S <: Session, R <: RecoveryMetadata](
             headers = Map("Location" ->
               (getRequestPathInfo(request) + url(getSession, "id" -> session.id.toString))))
         } catch {
+          case e: StateFileCollisionException =>
+            // All retries exhausted: the session id could not be claimed
+            // exclusively in the state store. Signal the client to retry
+            // rather than surfacing an opaque 500.
+            ServiceUnavailable(ResponseMessage("Rejected, Reason: " + e.getMessage),
+              headers = Map("Retry-After" -> "1"))
           case e: IllegalArgumentException =>
             BadRequest(ResponseMessage("Rejected, Reason: " + e.getMessage))
         }

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSession.scala
@@ -24,7 +24,7 @@ import scala.util.Random
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.apache.livy.{LivyConf, Logging, Utils}
 import org.apache.livy.server.AccessManager
-import org.apache.livy.server.recovery.SessionStore
+import org.apache.livy.server.recovery.{SessionStore, StateFileCollisionException}
 import org.apache.livy.sessions.{FinishedSessionState, Session, SessionState}
 import org.apache.livy.sessions.Session._
 import org.apache.livy.utils.{AppInfo, SparkApp, SparkAppListener, SparkProcessBuilder}
@@ -64,6 +64,20 @@ object BatchSession extends Logging {
     val appTag = s"livy-batch-$id-${Random.alphanumeric.take(8).mkString}".toLowerCase()
     val impersonatedUser = accessManager.checkImpersonation(proxyUser, owner)
     val namespace = SparkApp.getNamespace(request.conf, livyConf)
+
+    // Claim the session id exclusively in the state store before constructing
+    // the session object so collisions surface synchronously to the retry
+    // wrapper in SessionServlet -- the alternative (throwing inside the
+    // deferred createSparkApp lambda) fires after register() has already been
+    // called, outside the retry's scope.
+    val initialMetadata =
+      BatchRecoveryMetadata(id, name, None, appTag, owner, impersonatedUser, namespace)
+    if (!sessionStore.trySave(BatchSession.RECOVERY_SESSION_TYPE, initialMetadata)) {
+      throw new StateFileCollisionException(id, "batch")
+    }
+
+    // No try/catch needed here -- unlike InteractiveSession.create, nothing between
+    // trySave and the constructor does I/O. createSparkApp is a deferred lambda.
     def createSparkApp(s: BatchSession): SparkApp = {
       val conf = SparkApp.prepareSparkConf(
         appTag,
@@ -84,8 +98,6 @@ object BatchSession extends Logging {
       request.numExecutors.foreach(builder.numExecutors)
       request.queue.foreach(builder.queue)
       request.name.foreach(builder.name)
-
-      sessionStore.save(BatchSession.RECOVERY_SESSION_TYPE, s.recoveryMetadata)
 
       builder.redirectOutput(Redirect.PIPE)
       builder.redirectErrorStream(true)

--- a/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/batch/BatchSessionServlet.scala
@@ -45,17 +45,18 @@ class BatchSessionServlet(
 
   override protected def createSession(req: HttpServletRequest): BatchSession = {
     val createRequest = bodyAs[CreateBatchRequest](req)
-    val sessionId = sessionManager.nextId()
-    val sessionName = createRequest.name
-    BatchSession.create(
-      sessionId,
-      sessionName,
-      createRequest,
-      livyConf,
-      accessManager,
-      remoteUser(req),
-      proxyUser(req, createRequest.proxyUser),
-      sessionStore)
+    withCollisionRetry {
+      val sessionId = sessionManager.nextId()
+      BatchSession.create(
+        sessionId,
+        createRequest.name,
+        createRequest,
+        livyConf,
+        accessManager,
+        remoteUser(req),
+        proxyUser(req, createRequest.proxyUser),
+        sessionStore)
+    }
   }
 
   override protected[batch] def clientSessionView(

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSession.scala
@@ -29,6 +29,7 @@ import scala.collection.mutable
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.{Random, Try}
+import scala.util.control.NonFatal
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.apache.hadoop.fs.Path
@@ -39,7 +40,7 @@ import org.apache.livy.client.common.HttpMessages._
 import org.apache.livy.rsc.{PingJob, RSCClient, RSCConf}
 import org.apache.livy.rsc.driver.Statement
 import org.apache.livy.server.AccessManager
-import org.apache.livy.server.recovery.SessionStore
+import org.apache.livy.server.recovery.{SessionStore, StateFileCollisionException}
 import org.apache.livy.sessions._
 import org.apache.livy.sessions.Session._
 import org.apache.livy.sessions.SessionState.Dead
@@ -96,67 +97,99 @@ object InteractiveSession extends Logging {
     val impersonatedUser = accessManager.checkImpersonation(proxyUser, owner)
     val namespace = SparkApp.getNamespace(request.conf, livyConf)
 
-    val client = mockClient.orElse {
-      val conf = SparkApp.prepareSparkConf(appTag, livyConf, prepareConf(
-        request.conf, request.jars, request.files, request.archives, request.pyFiles, livyConf))
-
-      val builderProperties = prepareBuilderProp(conf, request.kind, livyConf)
-
-      val userOpts: Map[String, Option[String]] = Map(
-        "spark.driver.cores" -> request.driverCores.map(_.toString),
-        SparkLauncher.DRIVER_MEMORY -> request.driverMemory.map(_.toString),
-        SparkLauncher.EXECUTOR_CORES -> request.executorCores.map(_.toString),
-        SparkLauncher.EXECUTOR_MEMORY -> request.executorMemory.map(_.toString),
-        "spark.executor.instances" -> request.numExecutors.map(_.toString),
-        "spark.app.name" -> request.name.map(_.toString),
-        "spark.yarn.queue" -> request.queue
-      )
-
-      userOpts.foreach { case (key, opt) =>
-        opt.foreach { value => builderProperties.put(key, value) }
-      }
-
-      builderProperties.getOrElseUpdate("spark.app.name", s"livy-session-$id")
-
-      info(s"Creating Interactive session $id: [owner: $owner, request: $request]")
-      val builder = new LivyClientBuilder()
-        .setAll(builderProperties.asJava)
-        .setConf("livy.client.session-id", id.toString)
-        .setConf(RSCConf.Entry.DRIVER_CLASS.key(), "org.apache.livy.repl.ReplDriver")
-        .setConf(RSCConf.Entry.PROXY_USER.key(), impersonatedUser.orNull)
-        .setURI(new URI("rsc:/"))
-
-      Option(builder.build().asInstanceOf[RSCClient])
+    // Claim the session id exclusively in the state store before constructing
+    // the session object so collisions surface synchronously to the retry
+    // wrapper in SessionServlet -- throwing inside start() (invoked later via
+    // SessionManager.register) fires outside the retry's scope.
+    val initialMetadata = InteractiveRecoveryMetadata(
+      id, request.name, None, appTag, request.kind,
+      request.heartbeatTimeoutInSecond, owner, ttl, idleTimeout,
+      request.driverMemory, request.driverCores, request.executorMemory, request.executorCores,
+      request.conf, request.archives, request.files, request.jars,
+      request.numExecutors, request.pyFiles, request.queue,
+      impersonatedUser, None, namespace)
+    if (!sessionStore.trySave(RECOVERY_SESSION_TYPE, initialMetadata)) {
+      throw new StateFileCollisionException(id, "interactive")
     }
 
-    new InteractiveSession(
-      id,
-      name,
-      None,
-      appTag,
-      client,
-      SessionState.Starting,
-      request.kind,
-      request.heartbeatTimeoutInSecond,
-      livyConf,
-      owner,
-      impersonatedUser,
-      ttl,
-      idleTimeout,
-      sessionStore,
-      request.driverMemory,
-      request.driverCores,
-      request.executorMemory,
-      request.executorCores,
-      request.conf,
-      request.archives,
-      request.files,
-      request.jars,
-      request.numExecutors,
-      request.pyFiles,
-      request.queue,
-      namespace,
-      mockApp)
+    var client: Option[RSCClient] = None
+    try {
+      client = mockClient.orElse {
+        val conf = SparkApp.prepareSparkConf(appTag, livyConf, prepareConf(
+          request.conf, request.jars, request.files, request.archives, request.pyFiles, livyConf))
+
+        val builderProperties = prepareBuilderProp(conf, request.kind, livyConf)
+
+        val userOpts: Map[String, Option[String]] = Map(
+          "spark.driver.cores" -> request.driverCores.map(_.toString),
+          SparkLauncher.DRIVER_MEMORY -> request.driverMemory.map(_.toString),
+          SparkLauncher.EXECUTOR_CORES -> request.executorCores.map(_.toString),
+          SparkLauncher.EXECUTOR_MEMORY -> request.executorMemory.map(_.toString),
+          "spark.executor.instances" -> request.numExecutors.map(_.toString),
+          "spark.app.name" -> request.name.map(_.toString),
+          "spark.yarn.queue" -> request.queue
+        )
+
+        userOpts.foreach { case (key, opt) =>
+          opt.foreach { value => builderProperties.put(key, value) }
+        }
+
+        builderProperties.getOrElseUpdate("spark.app.name", s"livy-session-$id")
+
+        info(s"Creating Interactive session $id: [owner: $owner, request: $request]")
+        val builder = new LivyClientBuilder()
+          .setAll(builderProperties.asJava)
+          .setConf("livy.client.session-id", id.toString)
+          .setConf(RSCConf.Entry.DRIVER_CLASS.key(), "org.apache.livy.repl.ReplDriver")
+          .setConf(RSCConf.Entry.PROXY_USER.key(), impersonatedUser.orNull)
+          .setURI(new URI("rsc:/"))
+
+        Option(builder.build().asInstanceOf[RSCClient])
+      }
+
+      new InteractiveSession(
+        id,
+        name,
+        None,
+        appTag,
+        client,
+        SessionState.Starting,
+        request.kind,
+        request.heartbeatTimeoutInSecond,
+        livyConf,
+        owner,
+        impersonatedUser,
+        ttl,
+        idleTimeout,
+        sessionStore,
+        request.driverMemory,
+        request.driverCores,
+        request.executorMemory,
+        request.executorCores,
+        request.conf,
+        request.archives,
+        request.files,
+        request.jars,
+        request.numExecutors,
+        request.pyFiles,
+        request.queue,
+        namespace,
+        mockApp)
+    } catch {
+      case NonFatal(e) =>
+        client.foreach(c => try c.stop(true) catch {
+          case NonFatal(stopEx) =>
+            warn(s"Failed to stop RSCClient during rollback for interactive session $id", stopEx)
+        })
+        try {
+          sessionStore.remove(RECOVERY_SESSION_TYPE, id)
+        } catch {
+          case NonFatal(rollbackEx) =>
+            warn(s"Failed to remove recovery file for interactive session $id " +
+              s"after create() failure", rollbackEx)
+        }
+        throw e
+    }
   }
 
   def recover(
@@ -462,7 +495,6 @@ class InteractiveSession(
   private var app: Option[SparkApp] = None
 
   override def start(): Unit = {
-    sessionStore.save(RECOVERY_SESSION_TYPE, recoveryMetadata)
     heartbeat()
     app = mockApp.orElse {
       val driverProcess = client.flatMap { c => Option(c.getDriverProcess) }

--- a/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
+++ b/server/src/main/scala/org/apache/livy/server/interactive/InteractiveSessionServlet.scala
@@ -53,9 +53,7 @@ class InteractiveSessionServlet(
 
   override protected def createSession(req: HttpServletRequest): InteractiveSession = {
     val createRequest = bodyAs[CreateInteractiveRequest](req)
-    val sessionId = sessionManager.nextId();
 
-    // Calling getTimeAsMs just to validate the ttl and idleTimeout values
     if (createRequest.ttl.isDefined) {
       ClientConf.getTimeAsMs(createRequest.ttl.get);
     }
@@ -63,17 +61,20 @@ class InteractiveSessionServlet(
       ClientConf.getTimeAsMs(createRequest.idleTimeout.get);
     }
 
-    InteractiveSession.create(
-      sessionId,
-      createRequest.name,
-      remoteUser(req),
-      proxyUser(req, createRequest.proxyUser),
-      livyConf,
-      accessManager,
-      createRequest,
-      sessionStore,
-      createRequest.ttl,
-      createRequest.idleTimeout)
+    withCollisionRetry {
+      val sessionId = sessionManager.nextId()
+      InteractiveSession.create(
+        sessionId,
+        createRequest.name,
+        remoteUser(req),
+        proxyUser(req, createRequest.proxyUser),
+        livyConf,
+        accessManager,
+        createRequest,
+        sessionStore,
+        createRequest.ttl,
+        createRequest.idleTimeout)
+    }
   }
 
   override protected[interactive] def clientSessionView(

--- a/server/src/main/scala/org/apache/livy/server/recovery/BlackholeStateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/BlackholeStateStore.scala
@@ -33,4 +33,6 @@ class BlackholeStateStore(livyConf: LivyConf) extends StateStore(livyConf) {
   def getChildren(key: String): Seq[String] = List.empty[String]
 
   def remove(key: String): Unit = {}
+
+  override def tryExclusiveCreate(key: String, value: Object): Boolean = true
 }

--- a/server/src/main/scala/org/apache/livy/server/recovery/FileSystemStateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/FileSystemStateStore.scala
@@ -19,6 +19,9 @@ package org.apache.livy.server.recovery
 
 import java.io.{FileNotFoundException, IOException}
 import java.net.URI
+import java.nio.ByteBuffer
+import java.nio.file.{FileAlreadyExistsException => NioFileAlreadyExistsException, Files, Path => NioPath, Paths, StandardOpenOption}
+import java.nio.file.attribute.PosixFilePermissions
 import java.util
 import java.util.concurrent.TimeUnit
 
@@ -137,6 +140,71 @@ class FileSystemStateStore(
       fileContext.delete(absPath(key), false)
     } catch {
       case _: FileNotFoundException => warn(s"Failed to remove non-existed file: ${key}")
+    }
+  }
+
+  override def tryExclusiveCreate(key: String, value: Object): Boolean = {
+    if (fsUri.getScheme == "file" || fsUri.getScheme == null) {
+      tryExclusiveCreateNio(key, value)
+    } else {
+      tryExclusiveCreateHadoop(key, value)
+    }
+  }
+
+  /** True O_EXCL via kernel syscall -- for local/NFS/EFS mounts (file:// URIs).
+   *  NOTE: if write() fails after CREATE_NEW succeeds, the empty file remains
+   *  and that ID is permanently leaked. Acceptable trade-off -- tmp+rename
+   *  would break O_EXCL semantics. */
+  private def tryExclusiveCreateNio(key: String, value: Object): Boolean = {
+    val nioPath = Paths.get(fsUri.getPath, key)
+    Files.createDirectories(nioPath.getParent)
+    try {
+      val ownerOnly = PosixFilePermissions.asFileAttribute(
+        PosixFilePermissions.fromString("rw-------"))
+      val opts = util.EnumSet.of(
+        StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
+      val ch = Files.newByteChannel(nioPath, opts, ownerOnly)
+      try {
+        ch.write(ByteBuffer.wrap(serializeToBytes(value)))
+      } finally {
+        ch.close()
+      }
+      true
+    } catch {
+      case _: NioFileAlreadyExistsException => false
+      case _: UnsupportedOperationException =>
+        warn("POSIX file permissions not supported -- state file will use default umask.")
+        tryExclusiveCreateNioFallback(nioPath, value)
+    }
+  }
+
+  private def tryExclusiveCreateNioFallback(nioPath: NioPath, value: Object): Boolean = {
+    try {
+      val out = Files.newOutputStream(nioPath,
+        StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
+      try {
+        out.write(serializeToBytes(value))
+      } finally {
+        out.close()
+      }
+      true
+    } catch {
+      case _: NioFileAlreadyExistsException => false
+    }
+  }
+
+  /** Hadoop FileContext create without OVERWRITE -- safe on HDFS where NameNode
+   *  enforces exclusivity server-side. */
+  private def tryExclusiveCreateHadoop(key: String, value: Object): Boolean = {
+    val path = absPath(key)
+    try {
+      val flags = util.EnumSet.of(CreateFlag.CREATE)
+      usingResource(fileContext.create(path, flags, CreateOpts.createParent())) { out =>
+        out.write(serializeToBytes(value))
+      }
+      true
+    } catch {
+      case _: FileAlreadyExistsException => false
     }
   }
 

--- a/server/src/main/scala/org/apache/livy/server/recovery/SessionStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/SessionStore.scala
@@ -29,6 +29,18 @@ import org.apache.livy.sessions.Session.RecoveryMetadata
 private[recovery] case class SessionManagerState(nextSessionId: Int)
 
 /**
+ * Thrown when a session state file already exists during an exclusive create attempt.
+ * This indicates the given session id has already been claimed in the state store.
+ *
+ * @param sessionId The session ID that collided.
+ * @param sessionType The type of session ("batch" or "interactive").
+ */
+class StateFileCollisionException(val sessionId: Int, sessionType: String)
+  extends IllegalStateException(
+    s"State file for $sessionType session $sessionId already exists -- " +
+    "the id may have already been claimed.")
+
+/**
  * SessionStore provides high level functions to get/save session state from/to StateStore.
  */
 class SessionStore(
@@ -44,6 +56,14 @@ class SessionStore(
    */
   def save(sessionType: String, m: RecoveryMetadata): Unit = {
     store.set(sessionPath(sessionType, m.id), m)
+  }
+
+  /**
+   * O_CREAT|O_EXCL: save only if no state file exists for this session yet.
+   * @return true if created, false if already existed.
+   */
+  def trySave(sessionType: String, m: RecoveryMetadata): Boolean = {
+    store.tryExclusiveCreate(sessionPath(sessionType, m.id), m)
   }
 
   def saveNextSessionId(sessionType: String, id: Int): Unit = {

--- a/server/src/main/scala/org/apache/livy/server/recovery/StateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/StateStore.scala
@@ -71,6 +71,15 @@ abstract class StateStore(livyConf: LivyConf) extends JsonMapper {
    * @throws Exception Throw when persisting the state store fails.
    */
   def remove(key: String): Unit
+
+  /**
+   * Atomic exclusive create (O_CREAT|O_EXCL). Fails if key already exists.
+   * Implementations MUST provide a globally-atomic create-if-absent; a
+   * check-then-set fallback is not acceptable here because it reintroduces
+   * the very race this method exists to close.
+   * @return true if this call created the key, false if it already existed.
+   */
+  def tryExclusiveCreate(key: String, value: Object): Boolean
 }
 
 /**

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperManager.scala
@@ -24,7 +24,7 @@ import org.apache.curator.framework.api.UnhandledErrorListener
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.retry.RetryNTimes
-import org.apache.zookeeper.KeeperException.NoNodeException
+import org.apache.zookeeper.KeeperException.{NodeExistsException, NoNodeException}
 
 import org.apache.livy.LivyConf
 import org.apache.livy.Logging
@@ -89,6 +89,23 @@ class ZooKeeperManager(
       curatorClient.create().creatingParentsIfNeeded().forPath(key, data)
     } else {
       curatorClient.setData().forPath(key, data)
+    }
+  }
+
+  /**
+   * Atomic create-if-absent. ZooKeeper's create() is exclusive by default and
+   * throws NodeExistsException if the znode is already present, giving us a
+   * cluster-wide O_CREAT|O_EXCL primitive.
+   *
+   * @return true if this call created the znode, false if it already existed.
+   */
+  def createIfAbsent(key: String, value: Object): Boolean = {
+    val data = serializeToBytes(value)
+    try {
+      curatorClient.create().creatingParentsIfNeeded().forPath(key, data)
+      true
+    } catch {
+      case _: NodeExistsException => false
     }
   }
 

--- a/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperStateStore.scala
+++ b/server/src/main/scala/org/apache/livy/server/recovery/ZooKeeperStateStore.scala
@@ -44,6 +44,10 @@ class ZooKeeperStateStore(
     zkManager.remove(prefixKey(key))
   }
 
+  override def tryExclusiveCreate(key: String, value: Object): Boolean = {
+    zkManager.createIfAbsent(prefixKey(key), value)
+  }
+
   def getZooKeeperManager(): ZooKeeperManager = {
     zkManager
   }

--- a/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
+++ b/server/src/main/scala/org/apache/livy/sessions/SessionManager.scala
@@ -89,7 +89,7 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
   private[this] final val sessionStateRetainedInSec =
     TimeUnit.MILLISECONDS.toNanos(livyConf.getTimeAsMs(LivyConf.SESSION_STATE_RETAIN_TIME))
 
-  mockSessions.getOrElse(recover()).foreach(register)
+  mockSessions.getOrElse(recover()).foreach(register(_, fromRecovery = true))
   new GarbageCollector().start()
 
   def nextId(): Int = synchronized {
@@ -98,7 +98,17 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
     id
   }
 
-  def register(session: S): S = {
+  def register(session: S): S = register(session, fromRecovery = false)
+
+  /**
+   * fromRecovery=true means the session was loaded from an existing state-store
+   * entry (recover() at startup or refresh() re-scan). In that case the state
+   * file is authoritative -- it was written by an external writer or a prior
+   * run -- and we MUST NOT delete it on a local start() failure or name conflict.
+   * Only fresh-create flows (servlet POST) own their state file and should roll
+   * it back on failure.
+   */
+  private def register(session: S, fromRecovery: Boolean): S = {
     synchronized {
       sessions.get(session.id) match {
         case Some(existing) =>
@@ -111,17 +121,44 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
         if (sessionsByName.contains(sessionName)) {
           val errMsg = s"Duplicate session name: ${session.name} for session ${session.id}"
           error(errMsg)
-          session.stop()
+          if (!fromRecovery) {
+            // Fresh-create path owns the state file (Session.create calls
+            // trySave before returning); roll it back so we don't leak an
+            // orphan recovery file that nothing will ever clean up.
+            removeQuietly(session.id)
+            session.stop()
+          }
           throw new IllegalArgumentException(errMsg)
         } else {
           sessionsByName.put(sessionName, session)
         }
       }
       sessions.put(session.id, session)
-      session.start()
+      try {
+        session.start()
+      } catch {
+        case NonFatal(e) =>
+          sessions.remove(session.id)
+          session.name.foreach(sessionsByName.remove)
+          if (!fromRecovery) {
+            // Same rollback as above: start() owns spinning up the spark process
+            // / RSC client and can fail after the id is already claimed.
+            removeQuietly(session.id)
+          }
+          throw e
+      }
     }
     info(s"Registered new session ${session.id}")
     session
+  }
+
+  private def removeQuietly(id: Int): Unit = {
+    try {
+      sessionStore.remove(sessionType, id)
+    } catch {
+      case NonFatal(e) =>
+        warn(s"Failed to remove recovery file for session $id after registration failure", e)
+    }
   }
 
   def get(id: Int): Option[S] = sessions.get(id)
@@ -253,7 +290,7 @@ class SessionManager[S <: Session, R <: RecoveryMetadata : ClassTag](
       sessionMetadata.flatMap(_.toOption)
         .filterNot(m => sessions.contains(m.id))
         .map(sessionRecovery)
-        .foreach(register)
+        .foreach(register(_, fromRecovery = true))
 
       val added = sessions.size - before
       info(s"Refreshed $sessionType sessions: added=$added, total=${sessions.size}," +

--- a/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
@@ -270,6 +270,8 @@ class SparkKubernetesApp private[utils] (
   private var kubernetesDiagnostics: IndexedSeq[String] = IndexedSeq.empty[String]
   private var kubernetesAppLog: IndexedSeq[String] = IndexedSeq.empty[String]
 
+  // Latches the first observed app ID; subsequent polls returning a different ID are rejected.
+  @volatile private var knownAppId: Option[String] = appIdOption
   private var kubernetesTagToAppIdFailedTimes: Int = _
   private var kubernetesAppMonitorFailedTimes: Int = _
 
@@ -323,8 +325,26 @@ class SparkKubernetesApp private[utils] (
         return
       }
       val app: KubernetesApplication = appOption.get
-      appPromise.trySuccess(app)
       val appId = app.getApplicationId
+
+      knownAppId match {
+        case Some(known) if known != appId =>
+          val msg = s"App ID changed for tag $appTag: was $known, now $appId. Rejecting."
+          error(msg)
+          // Fail the promise so consumers blocked on Await.result(appPromise.future, ...)
+          // surface the mismatch immediately instead of waiting the full appLookupTimeout.
+          appPromise.tryFailure(new IllegalStateException(msg))
+          // Drive the session to FAILED, destroy the spark-submit process, and mark the
+          // tag as leaked so the monitor doesn't keep polling. Mirrors the treatment of
+          // other terminal failures (e.g. failToGetAppId exhausted).
+          kubernetesDiagnostics = ArrayBuffer(msg)
+          failToMonitor()
+          return
+        case None =>
+          knownAppId = Some(appId)
+        case _ => // Same app ID re-polled; no-op.
+      }
+      appPromise.trySuccess(app)
 
       Thread.currentThread().setName(s"kubernetesAppMonitorThread-$appId")
       listener.foreach(_.appIdKnown(appId))

--- a/server/src/test/scala/org/apache/livy/server/SessionServletRetrySpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/SessionServletRetrySpec.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.server
+
+import javax.servlet.http.HttpServletRequest
+
+import org.scalatest.FunSpec
+import org.scalatest.Matchers._
+
+import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
+import org.apache.livy.server.recovery.StateFileCollisionException
+import org.apache.livy.sessions.{Session, SessionManager, SessionState}
+import org.apache.livy.sessions.Session.RecoveryMetadata
+
+class SessionServletRetrySpec extends FunSpec with LivyBaseUnitTestSuite {
+
+  private case class StubMeta(id: Int) extends RecoveryMetadata
+  private class StubSession(id: Int, conf: LivyConf)
+    extends Session(id, None, "owner", conf) {
+    override val proxyUser: Option[String] = None
+    override def recoveryMetadata: RecoveryMetadata = StubMeta(id)
+    override def state: SessionState = SessionState.Idle
+    override def start(): Unit = ()
+    override protected def stopSession(): Unit = ()
+    override def logLines(): IndexedSeq[String] = IndexedSeq.empty
+  }
+
+  // Anonymous subclass exposing the protected withCollisionRetry helper.
+  private class TestableServlet(conf: LivyConf, mgr: SessionManager[Session, RecoveryMetadata])
+    extends SessionServlet[Session, RecoveryMetadata](mgr, conf, new AccessManager(conf)) {
+    override protected def createSession(req: HttpServletRequest): Session =
+      throw new UnsupportedOperationException("not used in this spec")
+    def runRetry(body: => Session): Session = withCollisionRetry(body)
+  }
+
+  private def newServlet(conf: LivyConf = new LivyConf()): (TestableServlet, LivyConf) = {
+    val mgr = new SessionManager[Session, RecoveryMetadata](
+      conf,
+      { _ => assert(false).asInstanceOf[Session] },
+      null.asInstanceOf[org.apache.livy.server.recovery.SessionStore],
+      "test",
+      Some(Seq.empty))
+    (new TestableServlet(conf, mgr), conf)
+  }
+
+  describe("SessionServlet.withCollisionRetry") {
+    it("retries past a single StateFileCollisionException and returns the session") {
+      val (servlet, conf) = newServlet()
+      var attempts = 0
+      val produced = new StubSession(0, conf)
+      val result = servlet.runRetry {
+        attempts += 1
+        if (attempts == 1) throw new StateFileCollisionException(1, "batch")
+        produced
+      }
+      attempts shouldBe 2
+      result shouldBe produced
+    }
+
+    it("propagates the exception after exhausting MAX_ID_COLLISION_RETRIES") {
+      val (servlet, _) = newServlet()
+      var attempts = 0
+      val ex = intercept[StateFileCollisionException] {
+        servlet.runRetry {
+          attempts += 1
+          throw new StateFileCollisionException(attempts, "batch")
+        }
+      }
+      // Initial attempt + 10 retries = 11 invocations before the final throw escapes.
+      attempts shouldBe 11
+      ex shouldBe a[StateFileCollisionException]
+    }
+
+    it("honors a configured max-retries value") {
+      val conf = new LivyConf().set(LivyConf.SESSION_ID_COLLISION_MAX_RETRIES, 2)
+      val (servlet, _) = newServlet(conf)
+      var attempts = 0
+      intercept[StateFileCollisionException] {
+        servlet.runRetry {
+          attempts += 1
+          throw new StateFileCollisionException(attempts, "batch")
+        }
+      }
+      // Initial attempt + 2 retries = 3 invocations.
+      attempts shouldBe 3
+    }
+
+    it("does not retry on a non-collision exception") {
+      val (servlet, _) = newServlet()
+      var attempts = 0
+      intercept[IllegalArgumentException] {
+        servlet.runRetry {
+          attempts += 1
+          throw new IllegalArgumentException("not a collision")
+        }
+      }
+      attempts shouldBe 1
+    }
+
+    it("returns immediately on first-attempt success without invoking body twice") {
+      val (servlet, conf) = newServlet()
+      var attempts = 0
+      val produced = new StubSession(0, conf)
+      val result = servlet.runRetry {
+        attempts += 1
+        produced
+      }
+      attempts shouldBe 1
+      result shouldBe produced
+    }
+  }
+}

--- a/server/src/test/scala/org/apache/livy/server/recovery/StateFileCollisionSpec.scala
+++ b/server/src/test/scala/org/apache/livy/server/recovery/StateFileCollisionSpec.scala
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.livy.server.recovery
+
+import java.io.File
+import java.nio.file.{Files, Paths, StandardOpenOption}
+import java.nio.file.attribute.PosixFilePermission._
+import java.util.concurrent.{CountDownLatch, CyclicBarrier, Executors, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.collection.JavaConverters._
+
+import org.scalatest.{BeforeAndAfterEach, FunSpec}
+import org.scalatest.Matchers._
+
+import org.apache.livy.{LivyBaseUnitTestSuite, LivyConf}
+import org.apache.livy.sessions.Session.RecoveryMetadata
+
+class StateFileCollisionSpec extends FunSpec
+  with BeforeAndAfterEach with LivyBaseUnitTestSuite {
+
+  private var tmpDir: File = _
+  private var stateStore: FileSystemStateStore = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    tmpDir = Files.createTempDirectory("livy-collision-test-").toFile
+    val conf = new LivyConf()
+    conf.set(LivyConf.RECOVERY_STATE_STORE_URL, s"file://${tmpDir.getAbsolutePath}")
+    stateStore = new FileSystemStateStore(conf)
+  }
+
+  override def afterEach(): Unit = {
+    if (tmpDir != null && tmpDir.exists()) {
+      def deleteRecursive(f: File): Unit = {
+        if (f.isDirectory) f.listFiles().foreach(deleteRecursive)
+        f.delete()
+      }
+      deleteRecursive(tmpDir)
+    }
+    super.afterEach()
+  }
+
+  describe("StateFileCollisionSpec") {
+    it("should return true on first exclusive create and false on duplicate") {
+      val key = "v1/batch/100"
+      stateStore.tryExclusiveCreate(key, "instance-A") shouldBe true
+      stateStore.tryExclusiveCreate(key, "instance-B") shouldBe false
+    }
+
+    it("should create state files with owner-only permissions (0600)") {
+      val key = "v1/batch/perm-check"
+      stateStore.tryExclusiveCreate(key, "perm-test") shouldBe true
+      val perms = Files.getPosixFilePermissions(
+        Paths.get(tmpDir.getAbsolutePath, key)).asScala
+      perms shouldBe Set(OWNER_READ, OWNER_WRITE)
+    }
+
+    it("should allow exactly one winner when N threads race via tryExclusiveCreate") {
+      val numThreads = 10
+      val raceKey = "v1/batch/excl-race"
+      val raceBarrier = new CyclicBarrier(numThreads)
+      val raceWins = new AtomicInteger(0)
+      val raceLosses = new AtomicInteger(0)
+      val racePool = Executors.newFixedThreadPool(numThreads)
+
+      for (i <- 0 until numThreads) {
+        racePool.submit(new Runnable {
+          override def run(): Unit = {
+            raceBarrier.await()
+            if (stateStore.tryExclusiveCreate(raceKey, s"thread-$i")) {
+              raceWins.incrementAndGet()
+            } else {
+              raceLosses.incrementAndGet()
+            }
+          }
+        })
+      }
+
+      racePool.shutdown()
+      racePool.awaitTermination(30, TimeUnit.SECONDS) shouldBe true
+      raceWins.get() shouldBe 1
+      raceLosses.get() shouldBe (numThreads - 1)
+    }
+
+    it("should allow exactly one winner when N threads race via NIO CREATE_NEW directly") {
+      val targetFile = new File(tmpDir, "v1/batch/nio-race-test")
+      targetFile.getParentFile.mkdirs()
+      val numThreads = 10
+      val barrier = new CyclicBarrier(numThreads)
+      val wins = new AtomicInteger(0)
+      val losses = new AtomicInteger(0)
+      val pool = Executors.newFixedThreadPool(numThreads)
+
+      for (_ <- 0 until numThreads) {
+        pool.submit(new Runnable {
+          override def run(): Unit = {
+            barrier.await()
+            try {
+              Files.write(
+                targetFile.toPath,
+                s"thread-${Thread.currentThread().getId}".getBytes,
+                StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
+              wins.incrementAndGet()
+            } catch {
+              case _: java.nio.file.FileAlreadyExistsException =>
+                losses.incrementAndGet()
+            }
+          }
+        })
+      }
+
+      pool.shutdown()
+      pool.awaitTermination(30, TimeUnit.SECONDS) shouldBe true
+      wins.get() shouldBe 1
+      losses.get() shouldBe (numThreads - 1)
+    }
+
+    it("should succeed on the next ID after a failed claim") {
+      val baseId = 200
+      stateStore.tryExclusiveCreate(s"v1/batch/$baseId", "instance-A") shouldBe true
+      stateStore.tryExclusiveCreate(s"v1/batch/$baseId", "instance-B") shouldBe false
+      stateStore.tryExclusiveCreate(s"v1/batch/${baseId + 1}", "instance-B") shouldBe true
+    }
+
+    it("should give two racing Livy instances distinct session IDs") {
+      val sharedIdCounter = new AtomicInteger(300)
+      val barrier = new CyclicBarrier(2)
+      val latch = new CountDownLatch(2)
+      val results = new java.util.concurrent.ConcurrentHashMap[String, Int]()
+      val pool = Executors.newFixedThreadPool(2)
+
+      for (instance <- Seq("livy-old-pod", "livy-new-pod")) {
+        pool.submit(new Runnable {
+          override def run(): Unit = {
+            barrier.await()
+            var claimed = false
+            var id = -1
+            while (!claimed) {
+              id = sharedIdCounter.getAndIncrement()
+              claimed = stateStore.tryExclusiveCreate(s"v1/batch/$id", instance)
+            }
+            results.put(instance, id)
+            latch.countDown()
+          }
+        })
+      }
+
+      latch.await(30, TimeUnit.SECONDS) shouldBe true
+      pool.shutdown()
+      results.get("livy-old-pod") should not equal results.get("livy-new-pod")
+    }
+
+    it("should reject app ID change after initial latch (knownAppId immutability)") {
+      var knownAppId: Option[String] = None
+
+      def monitorPoll(newAppId: String): Boolean = {
+        knownAppId match {
+          case Some(known) if known != newAppId => false
+          case None =>
+            knownAppId = Some(newAppId)
+            true
+          case _ => true
+        }
+      }
+
+      monitorPoll("spark-app-001") shouldBe true
+      monitorPoll("spark-app-001") shouldBe true
+      monitorPoll("spark-app-002") shouldBe false
+    }
+
+    it("should accept the same app ID on repeated polls") {
+      var knownAppId: Option[String] = None
+
+      def monitorPoll(newAppId: String): Boolean = {
+        knownAppId match {
+          case Some(known) if known != newAppId => false
+          case None =>
+            knownAppId = Some(newAppId)
+            true
+          case _ => true
+        }
+      }
+
+      for (_ <- 0 until 100) {
+        monitorPoll("spark-app-stable") shouldBe true
+      }
+    }
+
+    it("should preserve recovered app ID and reject a different one") {
+      var knownAppId: Option[String] = Some("spark-app-recovered-001")
+
+      def monitorPoll(newAppId: String): Boolean = {
+        knownAppId match {
+          case Some(known) if known != newAppId => false
+          case None =>
+            knownAppId = Some(newAppId)
+            true
+          case _ => true
+        }
+      }
+
+      monitorPoll("spark-app-recovered-001") shouldBe true
+      monitorPoll("spark-app-different-002") shouldBe false
+    }
+
+    it("should wrap tryExclusiveCreate correctly via SessionStore.trySave") {
+      val conf = new LivyConf()
+      val sessionStore = new SessionStore(conf, stateStore)
+      case class TestMeta(id: Int) extends RecoveryMetadata
+
+      val meta = TestMeta(500)
+      sessionStore.trySave("batch", meta) shouldBe true
+      sessionStore.trySave("batch", meta) shouldBe false
+    }
+
+    it("should provide a typed StateFileCollisionException with session type in message") {
+      val batchEx = new StateFileCollisionException(42, "batch")
+      batchEx shouldBe a[IllegalStateException]
+      batchEx.sessionId shouldBe 42
+      batchEx.getMessage should include("batch session 42")
+
+      val interactiveEx = new StateFileCollisionException(7, "interactive")
+      interactiveEx.getMessage should include("interactive session 7")
+
+      intercept[StateFileCollisionException] { throw batchEx }
+    }
+
+    it("should produce unique IDs across two pods in a full rolling deploy simulation") {
+      case class SimulatedBatch(batchId: Int, sparkAppId: String, instanceName: String)
+
+      val sharedCounter = new AtomicInteger(400)
+      val completedBatches = new java.util.concurrent.ConcurrentLinkedQueue[SimulatedBatch]()
+      val barrier = new CyclicBarrier(2)
+      val latch = new CountDownLatch(2)
+      val pool = Executors.newFixedThreadPool(2)
+
+      for ((instance, sparkApp) <- Seq(("old-pod", "spark-app-OLD"), ("new-pod", "spark-app-NEW")))
+      {
+        pool.submit(new Runnable {
+          override def run(): Unit = {
+            barrier.await()
+            for (_ <- 0 until 5) {
+              var claimed = false
+              var id = -1
+              while (!claimed) {
+                id = sharedCounter.getAndIncrement()
+                claimed = stateStore.tryExclusiveCreate(s"v1/batch/$id", instance)
+              }
+
+              var knownAppId: Option[String] = Some(sparkApp)
+              val impostorId = s"spark-app-IMPOSTOR-$id"
+              val accepted = knownAppId match {
+                case Some(known) if known != impostorId => false
+                case _ => true
+              }
+              accepted shouldBe false
+
+              completedBatches.add(SimulatedBatch(id, sparkApp, instance))
+            }
+            latch.countDown()
+          }
+        })
+      }
+
+      latch.await(30, TimeUnit.SECONDS) shouldBe true
+      pool.shutdown()
+
+      val allBatches = new java.util.ArrayList[SimulatedBatch]()
+      val it = completedBatches.iterator()
+      while (it.hasNext) allBatches.add(it.next())
+
+      val batchIds = new java.util.HashSet[Int]()
+      val it2 = allBatches.iterator()
+      while (it2.hasNext) batchIds.add(it2.next().batchId)
+
+      allBatches.size() shouldBe 10
+      batchIds.size() shouldBe 10
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Session ids could collide across Livy instances — e.g. a recovered instance whose id counter is stale relative to the active one. When ids collided, the session state file was written with overwrite semantics, so one session's state could **silently overwrite** another's, losing the original session's recovery metadata. This is most likely during a rolling restart/handoff when two instances are briefly live.

## Fix

Claim each session state file with an **atomic exclusive create (O_CREAT|O_EXCL)** before the Spark app is launched. An id whose file already exists fails the claim instead of overwriting it, so an existing session can never be clobbered.

- `StateStore.tryExclusiveCreate` + `SessionStore.trySave`, implemented for FileSystem/HDFS (NIO `CREATE_NEW` / Hadoop `CreateFlag.CREATE`) and ZooKeeper (atomic `create`).
- Claim the id up front in batch and interactive session creation, so a collision surfaces before any Spark app is started.
- Retry creation with a fresh id on collision; map exhausted retries to a retriable **503 (Retry-After)** rather than a hard failure.
- Guard recovery/refresh imports with `fromRecovery` so importing another instance's sessions can't delete the authoritative state files on a transient `start()`.
- Latch the first observed appId in `SparkKubernetesApp` so a re-attach can't bind to a different Spark app.

## Guarantees

A live session's state can never be silently overwritten or lost. The only failure modes are a harmless orphaned/leaked file (best-effort cleanup) or a retriable 503.

Here is short explaination:

Every session writes a small state file named by its id (.../sessions/<id>). Today that write is "overwrite if exists," so two pods using the same id will clobber each other.

The fix changes that one write to an atomic create-only operation:

Local FS/HDFS: open the file with O_CREAT|O_EXCL (CREATE_NEW) — the OS guarantees only the first creator succeeds; any later create on the same id throws.
ZooKeeper: use the native create (which already fails if the node exists).
So the id is "claimed" atomically before we launch the Spark app. If the claim fails (id already taken), we don't overwrite — we retry creation with a fresh id, and if we run out of retries we return a retriable 503.

Net: first writer wins, the loser never corrupts the winner's state. Worst case is a harmless orphaned file or a retriable 503, never lost session state.

Code: StateStore.tryExclusiveCreate → SessionStore.trySave, called from batch/interactive session creation; retry/503 in SessionServlet.