### PR TITLE
fix: prefer spark container exit status over pod phase when sidecars …

### DIFF
--- a/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
+++ b/server/src/main/scala/org/apache/livy/utils/SparkKubernetesApp.scala
@@ -590,15 +590,13 @@ private[utils] case class KubernetesAppReport(driver: Option[Pod], executors: Se
   def getDriverState(driverPod: Pod): String = {
     val podStatus = driverPod.getStatus
     val phase = podStatus.getPhase.toLowerCase
-    // if not running with sidecars, just return the pod phase
     if (!livyConf.getBoolean(LivyConf.KUBERNETES_SPARK_SIDECAR_ENABLED)) {
       return phase
     }
-    if (phase != KubernetesApplicationState.RUNNING) {
-      return phase
-    }
-    // if the POD is still running, check spark container termination status
-    // default to pod phase if container state is indeterminate.
+    // When sidecars are enabled, prefer spark container's exit status over
+    // pod phase since a sidecar failure can mark the pod as "failed" even
+    // if the driver exited successfully. Default to pod phase if the spark
+    // container cannot be found (e.g. misconfigured container name).
     getTerminalState(podStatus).getOrElse(phase)
   }
 
@@ -607,7 +605,7 @@ private[utils] case class KubernetesAppReport(driver: Option[Pod], executors: Se
   def getTerminalState(podStatus: PodStatus): Option[String] = {
     import scala.collection.JavaConverters._
     val sparkContainerName = livyConf.get(LivyConf.KUBERNETES_SPARK_CONTAINER_NAME)
-    for (c <- podStatus.getContainerStatuses.asScala) {
+    for (c <- Option(podStatus.getContainerStatuses).map(_.asScala).getOrElse(Nil)) {
       if (c.getName ==  sparkContainerName && c.getState.getTerminated != null) {
         val exitCode = c.getState.getTerminated.getExitCode
         if (exitCode == 0) {


### PR DESCRIPTION
…are enabled

A sidecar failure can mark the pod as "failed" even when the spark driver exited successfully. Remove the early return on non-running pod phase so that getTerminalState is always consulted first, falling back to pod phase only when the spark container cannot be found.

Add null safety for getContainerStatuses which can be null when the pod is still in pending phase.
